### PR TITLE
Implement `kiota_serialization_text`

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: ['kiota_abstractions', 'kiota_http']
+        package: ['kiota_abstractions', 'kiota_http', 'kiota_serialization_text']
 
     name: '${{ matrix.package }}: Analyze & Test'
     runs-on: ubuntu-latest

--- a/.run/Test kiota_serialization_text.run.xml
+++ b/.run/Test kiota_serialization_text.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Test kiota_serialization_text" type="DartTestRunConfigurationType" factoryName="Dart Test">
+    <option name="filePath" value="$PROJECT_DIR$/packages/kiota_serialization_text/test" />
+    <option name="scope" value="FOLDER" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/packages/kiota_abstractions/lib/kiota_abstractions.dart
+++ b/packages/kiota_abstractions/lib/kiota_abstractions.dart
@@ -11,6 +11,7 @@ import 'dart:collection';
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:std_uritemplate/std_uritemplate.dart';
 import 'package:uuid/uuid.dart';
 

--- a/packages/kiota_abstractions/lib/kiota_abstractions.dart
+++ b/packages/kiota_abstractions/lib/kiota_abstractions.dart
@@ -29,6 +29,7 @@ part 'src/date_only.dart';
 part 'src/error_mappings.dart';
 part 'src/extensions/base_request_builder_extensions.dart';
 part 'src/extensions/date_only_extensions.dart';
+part 'src/extensions/duration_extensions.dart';
 part 'src/extensions/map_extensions.dart';
 part 'src/extensions/request_information_extensions.dart';
 part 'src/extensions/time_only_extensions.dart';

--- a/packages/kiota_abstractions/lib/src/date_only.dart
+++ b/packages/kiota_abstractions/lib/src/date_only.dart
@@ -7,7 +7,7 @@ part of '../kiota_abstractions.dart';
 /// way.
 ///
 /// It can only be used to represent a date in the Gregorian calendar.
-abstract class DateOnly {
+abstract class DateOnly implements Comparable<DateOnly> {
   /// Extracts the date part of a [DateTime] and creates an object implementing
   /// [DateOnly].
   factory DateOnly.fromDateTime(DateTime dateTime) {
@@ -49,8 +49,9 @@ abstract class DateOnly {
   int get day;
 }
 
+@immutable
 class _DateOnlyImpl implements DateOnly {
-  _DateOnlyImpl({
+  const _DateOnlyImpl({
     required this.day,
     required this.month,
     required this.year,
@@ -64,4 +65,29 @@ class _DateOnlyImpl implements DateOnly {
 
   @override
   final int year;
+
+  @override
+  int compareTo(DateOnly other) {
+    if (year != other.year) {
+      return year.compareTo(other.year);
+    }
+
+    if (month != other.month) {
+      return month.compareTo(other.month);
+    }
+
+    return day.compareTo(other.day);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is DateOnly) {
+      return compareTo(other) == 0;
+    }
+
+    return false;
+  }
+
+  @override
+  int get hashCode => year.hashCode ^ month.hashCode ^ day.hashCode;
 }

--- a/packages/kiota_abstractions/lib/src/extensions/duration_extensions.dart
+++ b/packages/kiota_abstractions/lib/src/extensions/duration_extensions.dart
@@ -1,0 +1,58 @@
+part of '../../kiota_abstractions.dart';
+
+extension DurationExtensions on Duration {
+  static Duration? tryParse(String? value) {
+    if (value == null) {
+      return null;
+    }
+
+    // This regex is based on the ISO 8601 duration format
+    final regex = RegExp(
+      r'^([-+])?P(?:([-+]?[0-9,.]*)Y)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)W)?(?:([-+]?[0-9,.]*)D)?(?:T(?:([-+]?[0-9,.]*)H)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)S)?)?$',
+    );
+
+    final match = regex.firstMatch(value);
+    if (match == null) {
+      throw ArgumentError('String does not follow correct format', 'value');
+    }
+
+    final sign = match.group(1) == '-' ? -1 : 1;
+    final fractionalYears = double.tryParse(match.group(2) ?? '') ?? 0;
+    final fractionalMonths = double.tryParse(match.group(3) ?? '') ?? 0;
+    final fractionalWeeks = double.tryParse(match.group(4) ?? '') ?? 0;
+    final fractionalDays = double.tryParse(match.group(5) ?? '') ?? 0;
+    final fractionalHours = double.tryParse(match.group(6) ?? '') ?? 0;
+    final fractionalMinutes = double.tryParse(match.group(7) ?? '') ?? 0;
+    final fractionalSeconds = double.tryParse(match.group(8) ?? '') ?? 0;
+
+    final totalMicroseconds =
+        (fractionalYears * 365 * Duration.microsecondsPerDay).round() +
+            (fractionalMonths * 30 * Duration.microsecondsPerDay).round() +
+            (fractionalWeeks * 7 * Duration.microsecondsPerDay).round() +
+            (fractionalDays * Duration.microsecondsPerDay).round() +
+            (fractionalHours * Duration.microsecondsPerHour).round() +
+            (fractionalMinutes * Duration.microsecondsPerMinute).round() +
+            (fractionalSeconds * Duration.microsecondsPerSecond).round();
+
+    final days = totalMicroseconds ~/ Duration.microsecondsPerDay;
+    final hours = (totalMicroseconds % Duration.microsecondsPerDay) ~/
+        Duration.microsecondsPerHour;
+    final minutes = (totalMicroseconds % Duration.microsecondsPerHour) ~/
+        Duration.microsecondsPerMinute;
+    final seconds = (totalMicroseconds % Duration.microsecondsPerMinute) ~/
+        Duration.microsecondsPerSecond;
+    final milliseconds = (totalMicroseconds % Duration.microsecondsPerSecond) ~/
+        Duration.microsecondsPerMillisecond;
+    final microseconds =
+        totalMicroseconds % Duration.microsecondsPerMillisecond;
+
+    return Duration(
+      days: sign * days,
+      hours: sign * hours,
+      minutes: sign * minutes,
+      seconds: sign * seconds,
+      milliseconds: sign * milliseconds,
+      microseconds: sign * microseconds,
+    );
+  }
+}

--- a/packages/kiota_abstractions/lib/src/time_only.dart
+++ b/packages/kiota_abstractions/lib/src/time_only.dart
@@ -5,7 +5,7 @@ part of '../kiota_abstractions.dart';
 /// This interface provides an abstraction layer over time only objects.
 /// It is used to represent time only values in a serialization format agnostic
 /// way.
-abstract class TimeOnly {
+abstract class TimeOnly implements Comparable<TimeOnly> {
   /// Extracts the time part of a [DateTime] and creates an object implementing
   /// [TimeOnly].
   factory TimeOnly.fromDateTime(DateTime dateTime) {
@@ -53,8 +53,9 @@ abstract class TimeOnly {
   int get milliseconds;
 }
 
+@immutable
 class _TimeOnlyImpl implements TimeOnly {
-  _TimeOnlyImpl({
+  const _TimeOnlyImpl({
     required this.hours,
     required this.minutes,
     required this.seconds,
@@ -72,4 +73,37 @@ class _TimeOnlyImpl implements TimeOnly {
 
   @override
   final int milliseconds;
+
+  @override
+  int compareTo(TimeOnly other) {
+    if (hours != other.hours) {
+      return hours.compareTo(other.hours);
+    }
+
+    if (minutes != other.minutes) {
+      return minutes.compareTo(other.minutes);
+    }
+
+    if (seconds != other.seconds) {
+      return seconds.compareTo(other.seconds);
+    }
+
+    return milliseconds.compareTo(other.milliseconds);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is TimeOnly) {
+      return compareTo(other) == 0;
+    }
+
+    return false;
+  }
+
+  @override
+  int get hashCode =>
+      hours.hashCode ^
+      minutes.hashCode ^
+      seconds.hashCode ^
+      milliseconds.hashCode;
 }

--- a/packages/kiota_abstractions/pubspec.yaml
+++ b/packages/kiota_abstractions/pubspec.yaml
@@ -14,6 +14,7 @@ environment:
   sdk: '>=3.2.6 <4.0.0'
 
 dependencies:
+  meta: ^1.14.0
   std_uritemplate: ^0.0.55
   uuid: ^4.3.3
 

--- a/packages/kiota_abstractions/test/extensions/duration_extensions_test.dart
+++ b/packages/kiota_abstractions/test/extensions/duration_extensions_test.dart
@@ -1,0 +1,100 @@
+import 'package:kiota_abstractions/kiota_abstractions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DurationExtensions', () {
+    test('tryParse simple', () {
+      const input = 'P4DT12H30M5S';
+      const expected = Duration(
+        days: 4,
+        hours: 12,
+        minutes: 30,
+        seconds: 5,
+      );
+
+      final actual = DurationExtensions.tryParse(input);
+
+      expect(actual, equals(expected));
+    });
+
+    test('tryParse with milliseconds', () {
+      const input = 'PT5.123S';
+      const expected = Duration(
+        seconds: 5,
+        milliseconds: 123,
+      );
+
+      final actual = DurationExtensions.tryParse(input);
+
+      expect(actual, equals(expected));
+    });
+
+    test('tryParse with overflow', () {
+      const input = 'PT36H65M61S';
+      const expected = Duration(
+        hours: 36,
+        minutes: 65,
+        seconds: 61,
+      );
+
+      final actual = DurationExtensions.tryParse(input);
+
+      expect(actual, equals(expected));
+    });
+
+    test('tryParse with all negative', () {
+      const input = '-P4DT12H30M5S';
+      const expected = Duration(
+        days: -4,
+        hours: -12,
+        minutes: -30,
+        seconds: -5,
+      );
+
+      final actual = DurationExtensions.tryParse(input);
+
+      expect(actual, equals(expected));
+    });
+
+    test('tryParse with single negative', () {
+      const input = 'P4DT-12H30M5S';
+      const expected = Duration(
+        days: 4,
+        hours: -12,
+        minutes: 30,
+        seconds: 5,
+      );
+
+      final actual = DurationExtensions.tryParse(input);
+
+      expect(actual, equals(expected));
+    });
+
+    test('tryParse one year', () {
+      const input = 'P1Y';
+      const expected = Duration(days: 365);
+
+      final actual = DurationExtensions.tryParse(input);
+
+      expect(actual, equals(expected));
+    });
+
+    test('tryParse one month', () {
+      const input = 'P1M';
+      const expected = Duration(days: 30);
+
+      final actual = DurationExtensions.tryParse(input);
+
+      expect(actual, equals(expected));
+    });
+
+    test('tryParse one week', () {
+      const input = 'P1W';
+      const expected = Duration(days: 7);
+
+      final actual = DurationExtensions.tryParse(input);
+
+      expect(actual, equals(expected));
+    });
+  });
+}

--- a/packages/kiota_serialization_text/README.md
+++ b/packages/kiota_serialization_text/README.md
@@ -1,0 +1,21 @@
+The `kiota_serialization_text` package is the Dart Text serialization library implementation to
+handle `text/plain` responses.
+
+## Usage
+
+Install the package in the generated project:
+
+> For now, you can add the git repository as a dependency in your `pubspec.yaml` file:
+>
+> ```yaml
+> dependencies:
+>   kiota_serialization_text:
+>     git:
+>       url: https://github.com/ricardoboss/dart_kiota.git
+>       ref: main
+>       path: packages/kiota_serialization_text
+> ```
+
+```bash
+dart pub add kiota_serialization_text
+```

--- a/packages/kiota_serialization_text/analysis_options.yaml
+++ b/packages/kiota_serialization_text/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:strict/analysis_options.yaml

--- a/packages/kiota_serialization_text/lib/kiota_serialization_text.dart
+++ b/packages/kiota_serialization_text/lib/kiota_serialization_text.dart
@@ -11,3 +11,4 @@ import 'package:kiota_abstractions/kiota_abstractions.dart';
 import 'package:uuid/uuid_value.dart';
 
 part 'src/text_parse_node.dart';
+part 'src/text_parse_node_factory.dart';

--- a/packages/kiota_serialization_text/lib/kiota_serialization_text.dart
+++ b/packages/kiota_serialization_text/lib/kiota_serialization_text.dart
@@ -1,0 +1,5 @@
+/// This library implements deserialization for text/plain responses.
+///
+/// This library is not meant to be used directly, but rather to be used as a
+/// dependency in the generated code.
+library kiota_serialization_text;

--- a/packages/kiota_serialization_text/lib/kiota_serialization_text.dart
+++ b/packages/kiota_serialization_text/lib/kiota_serialization_text.dart
@@ -3,3 +3,11 @@
 /// This library is not meant to be used directly, but rather to be used as a
 /// dependency in the generated code.
 library kiota_serialization_text;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:kiota_abstractions/kiota_abstractions.dart';
+import 'package:uuid/uuid_value.dart';
+
+part 'src/text_parse_node.dart';

--- a/packages/kiota_serialization_text/lib/kiota_serialization_text.dart
+++ b/packages/kiota_serialization_text/lib/kiota_serialization_text.dart
@@ -12,3 +12,4 @@ import 'package:uuid/uuid_value.dart';
 
 part 'src/text_parse_node.dart';
 part 'src/text_parse_node_factory.dart';
+part 'src/text_serialization_writer.dart';

--- a/packages/kiota_serialization_text/lib/kiota_serialization_text.dart
+++ b/packages/kiota_serialization_text/lib/kiota_serialization_text.dart
@@ -13,3 +13,4 @@ import 'package:uuid/uuid_value.dart';
 part 'src/text_parse_node.dart';
 part 'src/text_parse_node_factory.dart';
 part 'src/text_serialization_writer.dart';
+part 'src/text_serialization_writer_factory.dart';

--- a/packages/kiota_serialization_text/lib/src/text_parse_node.dart
+++ b/packages/kiota_serialization_text/lib/src/text_parse_node.dart
@@ -1,0 +1,121 @@
+part of '../kiota_serialization_text.dart';
+
+class TextParseNode implements ParseNode {
+  TextParseNode(String? text) : _text = _sanitize(text);
+
+  static String? _sanitize(String? text) {
+    if (text == null) {
+      return null;
+    }
+
+    var sanitized = text;
+
+    // trim " characters at beginning and end
+    if (sanitized.startsWith('"') && sanitized.endsWith('"')) {
+      sanitized = sanitized.substring(1, sanitized.length - 1);
+    }
+
+    return sanitized;
+  }
+
+  static UnsupportedError _noStructuredDataError() {
+    return UnsupportedError('Text does not support structured data');
+  }
+
+  final String? _text;
+
+  @override
+  ParsableHook? onAfterAssignFieldValues;
+
+  @override
+  ParsableHook? onBeforeAssignFieldValues;
+
+  @override
+  bool? getBoolValue() {
+    return _text == null ? null : bool.tryParse(_text);
+  }
+
+  @override
+  Uint8List? getByteArrayValue() {
+    return _text == null ? null : base64Decode(_text);
+  }
+
+  @override
+  ParseNode? getChildNode(String identifier) {
+    throw _noStructuredDataError();
+  }
+
+  @override
+  Iterable<T> getCollectionOfEnumValues<T extends Enum>() {
+    throw _noStructuredDataError();
+  }
+
+  @override
+  Iterable<T> getCollectionOfObjectValues<T extends Parsable>(
+    ParsableFactory<T> factory,
+  ) {
+    throw _noStructuredDataError();
+  }
+
+  @override
+  Iterable<T> getCollectionOfPrimitiveValues<T>() {
+    throw _noStructuredDataError();
+  }
+
+  @override
+  DateOnly? getDateOnlyValue() {
+    return _text == null ? null : DateOnly.fromDateTimeString(_text);
+  }
+
+  @override
+  DateTime? getDateTimeValue() {
+    return _text == null ? null : DateTime.tryParse(_text);
+  }
+
+  @override
+  double? getDoubleValue() {
+    return _text == null ? null : double.tryParse(_text);
+  }
+
+  @override
+  Duration? getDurationValue() {
+    return _text == null ? null : DurationExtensions.tryParse(_text);
+  }
+
+  @override
+  T? getEnumValue<T extends Enum>() {
+    if (_text == null) {
+      return null;
+    }
+
+    // We'd need something like a static abstract method to be able to get all
+    // the values of an enum, but Dart doesn't support that.
+    // see: https://github.com/dart-lang/language/issues/356
+    throw UnsupportedError('Enum parsing is not supported yet');
+  }
+
+  @override
+  UuidValue? getGuidValue() {
+    return _text == null ? null : UuidValue.withValidation(_text);
+  }
+
+  @override
+  int? getIntValue() {
+    return _text == null ? null : int.tryParse(_text);
+  }
+
+  @override
+  T? getObjectValue<T extends Parsable>(ParsableFactory<T> factory) {
+    throw _noStructuredDataError();
+  }
+
+  @override
+  String? getStringValue() {
+    return _text;
+  }
+
+  @override
+  TimeOnly? getTimeOnlyValue() {
+    return _text == null ? null : TimeOnly.fromDateTimeString(_text);
+  }
+}

--- a/packages/kiota_serialization_text/lib/src/text_parse_node_factory.dart
+++ b/packages/kiota_serialization_text/lib/src/text_parse_node_factory.dart
@@ -1,0 +1,17 @@
+part of '../kiota_serialization_text.dart';
+
+class TextParseNodeFactory implements ParseNodeFactory {
+  @override
+  ParseNode getRootParseNode(String contentType, Uint8List content) {
+    if (contentType != validContentType) {
+      throw ArgumentError('Invalid content type');
+    }
+
+    final text = utf8.decode(content);
+
+    return TextParseNode(text);
+  }
+
+  @override
+  String get validContentType => 'text/plain';
+}

--- a/packages/kiota_serialization_text/lib/src/text_serialization_writer.dart
+++ b/packages/kiota_serialization_text/lib/src/text_serialization_writer.dart
@@ -1,0 +1,116 @@
+part of '../kiota_serialization_text.dart';
+
+class TextSerializationWriter implements SerializationWriter {
+  final StringBuffer _buffer = StringBuffer();
+  bool _isFirst = true;
+
+  static UnsupportedError _noStructuredDataError() {
+    return UnsupportedError('Text does not support structured data');
+  }
+
+  @override
+  ParsableHook? onAfterObjectSerialization;
+
+  @override
+  ParsableHook? onBeforeObjectSerialization;
+
+  @override
+  void Function(Parsable p, SerializationWriter w)? onStartObjectSerialization;
+
+  @override
+  Uint8List getSerializedContent() {
+    return utf8.encode(_buffer.toString());
+  }
+
+  @override
+  void writeAdditionalData(Map<String, dynamic> value) {
+    throw _noStructuredDataError();
+  }
+
+  @override
+  void writeBoolValue(String? key, {bool? value}) {
+    writeStringValue(key, value?.toString());
+  }
+
+  @override
+  void writeByteArrayValue(String? key, Uint8List? value) {
+    writeStringValue(key, value == null ? null : base64Encode(value));
+  }
+
+  @override
+  void writeCollectionOfEnumValues<T extends Enum>(
+    String? key,
+    Iterable<T>? values,
+  ) {
+    throw _noStructuredDataError();
+  }
+
+  @override
+  void writeCollectionOfObjectValues<T extends Parsable>(
+    String? key,
+    Iterable<T>? values,
+  ) {
+    throw _noStructuredDataError();
+  }
+
+  @override
+  void writeCollectionOfPrimitiveValues<T>(String? key, Iterable<T>? values) {
+    throw _noStructuredDataError();
+  }
+
+  @override
+  void writeDateTimeValue(String? key, DateTime? value) {
+    writeStringValue(key, value?.toIso8601String());
+  }
+
+  @override
+  void writeDoubleValue(String? key, double? value) {
+    writeStringValue(key, value?.toString());
+  }
+
+  @override
+  void writeEnumValue<T extends Enum>(String? key, T? value) {
+    writeStringValue(key, value?.name);
+  }
+
+  @override
+  void writeIntValue(String? key, int? value) {
+    writeStringValue(key, value?.toString());
+  }
+
+  @override
+  void writeNullValue(String? key) {
+    writeStringValue(key, 'null');
+  }
+
+  @override
+  void writeObjectValue<T extends Parsable>(
+    String? key,
+    T? value, [
+    Iterable<Parsable>? additionalValuesToMerge,
+  ]) {
+    throw _noStructuredDataError();
+  }
+
+  @override
+  void writeStringValue(String? key, String? value) {
+    // text cannot have keys, so we throw if one is provided
+    if (key?.isNotEmpty ?? false) {
+      throw _noStructuredDataError();
+    }
+
+    // if the value is null or empty, we don't write anything
+    if (value?.isEmpty ?? true) {
+      return;
+    }
+
+    if (!_isFirst) {
+      throw UnsupportedError(
+        'A value was already written for this serialization writer, text content only supports a single value',
+      );
+    }
+
+    _isFirst = false;
+    _buffer.write(value);
+  }
+}

--- a/packages/kiota_serialization_text/lib/src/text_serialization_writer_factory.dart
+++ b/packages/kiota_serialization_text/lib/src/text_serialization_writer_factory.dart
@@ -1,0 +1,17 @@
+part of '../kiota_serialization_text.dart';
+
+class TextSerializationWriterFactory implements SerializationWriterFactory {
+  @override
+  SerializationWriter getSerializationWriter(String contentType) {
+    if (contentType != validContentType) {
+      throw ArgumentError(
+        'The provided content type is not supported by the TextSerializationWriterFactory',
+      );
+    }
+
+    return TextSerializationWriter();
+  }
+
+  @override
+  String get validContentType => 'text/plain';
+}

--- a/packages/kiota_serialization_text/pubspec.yaml
+++ b/packages/kiota_serialization_text/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   kiota_abstractions:
     path: ../kiota_abstractions
+  uuid: ^4.3.3
 
 dev_dependencies:
   strict: ^2.0.0

--- a/packages/kiota_serialization_text/pubspec.yaml
+++ b/packages/kiota_serialization_text/pubspec.yaml
@@ -1,0 +1,16 @@
+name: kiota_serialization_text
+description: "Kiota text serialization for Dart"
+version: 0.0.1-pre.1
+homepage: https://github.com/ricardoboss/dart_kiota/tree/main/packages/kiota_serialization_text
+publish_to: 'none'
+
+environment:
+  sdk: '>=3.2.6 <4.0.0'
+
+dependencies:
+  kiota_abstractions:
+    path: ../kiota_abstractions
+
+dev_dependencies:
+  strict: ^2.0.0
+  test: ^1.25.2

--- a/packages/kiota_serialization_text/test/test_parse_node_test.dart
+++ b/packages/kiota_serialization_text/test/test_parse_node_test.dart
@@ -1,0 +1,187 @@
+import 'package:kiota_abstractions/kiota_abstractions.dart';
+import 'package:kiota_serialization_text/kiota_serialization_text.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+void main() {
+  group('TextParseNode', () {
+    final throwsNoStructuredDataError = throwsA(
+      isA<UnsupportedError>().having(
+        (e) => e.message,
+        'message',
+        equals('Text does not support structured data'),
+      ),
+    );
+
+    test('trims quotes', () {
+      final node = TextParseNode('"value"');
+
+      expect(node.getStringValue(), equals('value'));
+    });
+
+    test('leaves quotes if unbalanced', () {
+      final preQuote = TextParseNode('"value');
+      final postQuote = TextParseNode('value"');
+
+      expect(preQuote.getStringValue(), equals('"value'));
+      expect(postQuote.getStringValue(), equals('value"'));
+    });
+
+    test('getStringValue', () {
+      final node = TextParseNode('value');
+
+      expect(node.getStringValue(), equals('value'));
+    });
+
+    test('getBoolValue', () {
+      final node = TextParseNode('true');
+
+      expect(node.getBoolValue(), equals(true));
+    });
+
+    test('getByteArrayValue', () {
+      final node = TextParseNode('dGVzdA==');
+
+      expect(node.getByteArrayValue(), equals([116, 101, 115, 116]));
+    });
+
+    test('getDateOnlyValue', () {
+      final node = TextParseNode('2021-01-01');
+
+      expect(
+        node.getDateOnlyValue(),
+        equals(DateOnly.fromComponents(2021)),
+      );
+    });
+
+    test('getDateTimeValue', () {
+      final node = TextParseNode('2021-01-01T00:00:00Z');
+
+      expect(
+        node.getDateTimeValue(),
+        equals(DateTime.utc(2021)),
+      );
+    });
+
+    test('getDoubleValue', () {
+      final node = TextParseNode('1.23');
+
+      expect(node.getDoubleValue(), equals(1.23));
+    });
+
+    test('getDurationValue', () {
+      final node = TextParseNode('P3DT4H5M6S');
+
+      expect(
+        node.getDurationValue(),
+        equals(
+          const Duration(
+            days: 3,
+            hours: 4,
+            minutes: 5,
+            seconds: 6,
+          ),
+        ),
+      );
+    });
+
+    test('getGuidValue nil', () {
+      final node = TextParseNode('00000000-0000-0000-0000-000000000000');
+
+      expect(
+        node.getGuidValue(),
+        equals(UuidValue.nil),
+      );
+    });
+
+    test('getGuidValue', () {
+      final node = TextParseNode('1f8a1626-369d-41df-bcc4-af5c5adbbd0a');
+
+      expect(
+        node.getGuidValue(),
+        equals(UuidValue.fromString('1f8a1626-369d-41df-bcc4-af5c5adbbd0a')),
+      );
+    });
+
+    test('getIntValue', () {
+      final node = TextParseNode('123');
+
+      expect(node.getIntValue(), equals(123));
+    });
+
+    test('getTimeOnlyValue', () {
+      final node = TextParseNode('12:34:56');
+
+      expect(
+        node.getTimeOnlyValue(),
+        equals(
+          TimeOnly.fromComponents(12, 34, 56),
+        ),
+      );
+    });
+
+    test('getEnumValue', () {
+      final node = TextParseNode('value');
+
+      expect(
+        () => node.getEnumValue<HttpMethod>(),
+        throwsA(
+          isA<UnsupportedError>().having(
+            (e) => e.message,
+            'message',
+            equals('Enum parsing is not supported yet'),
+          ),
+        ),
+      );
+    });
+
+    test('getChildNode', () {
+      final node = TextParseNode('value');
+
+      expect(
+        () => node.getChildNode('identifier'),
+        throwsNoStructuredDataError,
+      );
+    });
+
+    test('getCollectionOfObjectValues', () {
+      final node = TextParseNode('value');
+
+      expect(
+        () => node.getCollectionOfObjectValues<MultipartBody>(
+          (_) => MultipartBody(),
+        ),
+        throwsNoStructuredDataError,
+      );
+    });
+
+    test('getCollectionOfPrimitiveValues', () {
+      final node = TextParseNode('value');
+
+      expect(
+        () => node.getCollectionOfPrimitiveValues<int>(),
+        throwsNoStructuredDataError,
+      );
+    });
+
+    test('getCollectionOfEnumValues', () {
+      final node = TextParseNode('value');
+
+      expect(
+        () => node.getCollectionOfEnumValues<HttpMethod>(),
+        throwsNoStructuredDataError,
+      );
+    });
+
+    test('getObjectValue', () {
+      final node = TextParseNode('value');
+
+      expect(
+        () => node.getObjectValue<MultipartBody>(
+          (_) => MultipartBody(),
+        ),
+        throwsNoStructuredDataError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #21

Enum deserialisation is currently not possible, because Dart doesn't have reflection. I linked to an issue that proposes to add abstract static members to classes, which would in turn allow the Dart SDK to provide static access to the `values` member of enums which would allow us to use it to deserialise a specific value.

In the meantime we either don't support enum deserialisation (not preferred) or we implement a workaround which would increase the amount of generated code (via static factories that register each available enum).