### PR TITLE
Run additional analysis

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
       - name: Prepare package
-        run: dart run tooling/bin/tooling.dart prepare ${{ matrix.package }}
+        run: dart run tooling prepare ${{ matrix.package }}
         working-directory: tooling
 
       - name: Analyze project source
@@ -96,7 +96,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
       - name: Prepare package
-        run: dart run tooling/bin/tooling.dart prepare ${{ matrix.package }}
+        run: dart run tooling prepare ${{ matrix.package }}
         working-directory: tooling
 
       - name: Run tests

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Run pana
         uses: axel-op/dart-package-analyzer@v3
         with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           relativePath: packages/${{ matrix.package }}
 
   test:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
       - name: Run build_runner
-        if: contains(fromJson('${{ env.build_runner_packages }}'), matrix.package)
+        if: contains(fromJson(${{ env.build_runner_packages }}), matrix.package)
         run: dart run build_runner build --delete-conflicting-outputs
         working-directory: packages/${{ matrix.package }}
 
@@ -100,7 +100,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
       - name: Run build_runner
-        if: contains(fromJson('${{ env.build_runner_packages }}'), matrix.package)
+        if: contains(fromJson(${{ env.build_runner_packages }}), matrix.package)
         run: dart run build_runner build --delete-conflicting-outputs
         working-directory: packages/${{ matrix.package }}
 

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Prepare package
         run: dart run tooling/bin/tooling.dart prepare ${{ matrix.package }}
+        working-directory: tooling
 
       - name: Analyze project source
         continue-on-error: true
@@ -96,6 +97,7 @@ jobs:
 
       - name: Prepare package
         run: dart run tooling/bin/tooling.dart prepare ${{ matrix.package }}
+        working-directory: tooling
 
       - name: Run tests
         run: dart test

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -7,14 +7,29 @@ on:
     branches: [ "main" ]
 
 jobs:
-  test:
+  define-matrix:
+    runs-on: ubuntu-latest
+
+    outputs:
+      packages: ${{ steps.packages.outputs.packages }}
+
+    steps:
+      - name: Determine packages
+        id: packages
+        run: |
+          packages=$(ls -d packages/* | jq -R -s -c 'split("\n")[:-1]')
+          echo "packages=${packages}" >> $GITHUB_OUTPUT
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    needs: define-matrix
+
     strategy:
       fail-fast: false
       matrix:
-        package: ['kiota_abstractions', 'kiota_http', 'kiota_serialization_form', 'kiota_serialization_text']
+        package: ${{ fromJson(needs.define-matrix.outputs.packages) }}
 
-    name: '${{ matrix.package }}: Analyze & Test'
-    runs-on: ubuntu-latest
+    name: '${{ matrix.package }}: Static Analysis'
 
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +59,41 @@ jobs:
       - name: Analyze project source
         continue-on-error: true
         run: dart analyze --fatal-infos
+        working-directory: packages/${{ matrix.package }}
+
+      - name: Run pana
+        uses: axel-op/dart-package-analyzer@v3
+        with:
+          relativePath: packages/${{ matrix.package }}
+
+  test:
+    runs-on: ubuntu-latest
+    needs: define-matrix
+
+    strategy:
+      matrix:
+        package: ${{ fromJson(needs.define-matrix.outputs.packages) }}
+
+    name: '${{ matrix.package }}: Test'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PUB_CACHE }}
+          key: ${{ runner.os }}-pub
+
+      - name: Install dependencies
+        run: dart pub get
+        working-directory: packages/${{ matrix.package }}
+
+      - name: Run build_runner
+        if: contains(fromJson('[ "kiota_abstractions", "kiota_http" ]'), matrix.package)
+        run: dart run build_runner build --delete-conflicting-outputs
         working-directory: packages/${{ matrix.package }}
 
       - name: Run tests

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Discover packages
         id: packages
         run: |
-          packages=$(ls -d packages/* | jq -R -s -c 'split("\n")[:-1]')
+          packages=$(ls -d packages/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')
           echo "packages=${packages}" >> $GITHUB_OUTPUT
 
   static-analysis:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  build_runner_packages: '[ "kiota_abstractions", "kiota_http", "kiota_serialization_form" ]'
-
 jobs:
   define-matrix:
     runs-on: ubuntu-latest
@@ -58,10 +55,8 @@ jobs:
         run: dart format --output=none --set-exit-if-changed .
         working-directory: packages/${{ matrix.package }}
 
-      - name: Run build_runner
-        if: contains(fromJson(${{ env.build_runner_packages }}), matrix.package)
-        run: dart run build_runner build --delete-conflicting-outputs
-        working-directory: packages/${{ matrix.package }}
+      - name: Prepare package
+        run: dart run tooling/bin/tooling.dart prepare ${{ matrix.package }}
 
       - name: Analyze project source
         continue-on-error: true
@@ -99,10 +94,8 @@ jobs:
         run: dart pub get
         working-directory: packages/${{ matrix.package }}
 
-      - name: Run build_runner
-        if: contains(fromJson(${{ env.build_runner_packages }}), matrix.package)
-        run: dart run build_runner build --delete-conflicting-outputs
-        working-directory: packages/${{ matrix.package }}
+      - name: Prepare package
+        run: dart run tooling/bin/tooling.dart prepare ${{ matrix.package }}
 
       - name: Run tests
         run: dart test

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -10,11 +10,15 @@ jobs:
   define-matrix:
     runs-on: ubuntu-latest
 
+    name: 'Discover packages'
+
     outputs:
       packages: ${{ steps.packages.outputs.packages }}
 
     steps:
-      - name: Determine packages
+      - uses: actions/checkout@v4
+
+      - name: Discover packages
         id: packages
         run: |
           packages=$(ls -d packages/* | jq -R -s -c 'split("\n")[:-1]')

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  build_runner_packages: '[ "kiota_abstractions", "kiota_http", "kiota_serialization_form" ]'
+
 jobs:
   define-matrix:
     runs-on: ubuntu-latest
@@ -56,7 +59,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
       - name: Run build_runner
-        if: contains(fromJson('[ "kiota_abstractions", "kiota_http", "kiota_serialization_form" ]'), matrix.package)
+        if: contains(fromJson('${{ env.build_runner_packages }}'), matrix.package)
         run: dart run build_runner build --delete-conflicting-outputs
         working-directory: packages/${{ matrix.package }}
 
@@ -97,7 +100,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
       - name: Run build_runner
-        if: contains(fromJson('[ "kiota_abstractions", "kiota_http" ]'), matrix.package)
+        if: contains(fromJson('${{ env.build_runner_packages }}'), matrix.package)
         run: dart run build_runner build --delete-conflicting-outputs
         working-directory: packages/${{ matrix.package }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 # ignore generated files
 gen/
 *.mocks.dart
+
+# Licenses for packages are not checked in; they are copied from the root
+packages/*/LICENSE

--- a/packages/kiota_abstractions/pubspec.yaml
+++ b/packages/kiota_abstractions/pubspec.yaml
@@ -2,6 +2,7 @@ name: kiota_abstractions
 description: "Provides interfaces and base classes for Dart Kiota clients."
 version: 0.0.1-pre.1
 homepage: https://github.com/ricardoboss/dart_kiota/tree/main/packages/kiota_abstractions
+repository: https://github.com/ricardoboss/dart_kiota
 publish_to: 'none'
 
 topics:

--- a/packages/kiota_abstractions/pubspec.yaml
+++ b/packages/kiota_abstractions/pubspec.yaml
@@ -15,9 +15,9 @@ environment:
   sdk: '>=3.2.6 <4.0.0'
 
 dependencies:
-  meta: ^1.14.0
-  std_uritemplate: ^0.0.55
-  uuid: ^4.3.3
+  meta: ^1.15.0
+  std_uritemplate: ^1.0.3
+  uuid: ^4.4.2
 
 dev_dependencies:
   strict: ^2.0.0

--- a/packages/kiota_abstractions/pubspec.yaml
+++ b/packages/kiota_abstractions/pubspec.yaml
@@ -1,7 +1,7 @@
 name: kiota_abstractions
-description: "Kiota abstractions for Dart"
+description: "Provides interfaces and base classes for Dart Kiota clients."
 version: 0.0.1-pre.1
-homepage: https://github.com/ricardoboss/dart_kiota_abstractions/tree/main/packages/kiota_abstractions
+homepage: https://github.com/ricardoboss/dart_kiota/tree/main/packages/kiota_abstractions
 publish_to: 'none'
 
 topics:

--- a/packages/kiota_http/CHANGELOG.md
+++ b/packages/kiota_http/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Unreleased
+
+- Initial version.
+- Provides an implementation of a `RequestAdapter` that uses `http` to send HTTP requests.

--- a/packages/kiota_http/example/lib/example.dart
+++ b/packages/kiota_http/example/lib/example.dart
@@ -6,7 +6,8 @@ import 'package:kiota_http/kiota_http.dart';
 
 Future<void> main() async {
   // Setup
-  ParseNodeFactoryRegistry.defaultInstance.contentTypeAssociatedFactories['application/json'] =
+  ParseNodeFactoryRegistry
+          .defaultInstance.contentTypeAssociatedFactories['application/json'] =
       _CatFactsParseNodeFactory();
   var client = KiotaClientFactory.createClient();
   var authProvider = AnonymousAuthenticationProvider();

--- a/packages/kiota_http/example/lib/example.dart
+++ b/packages/kiota_http/example/lib/example.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:kiota_abstractions/kiota_abstractions.dart';
+import 'package:kiota_http/kiota_http.dart';
+
+Future<void> main() async {
+  // Setup
+  ParseNodeFactoryRegistry.defaultInstance.contentTypeAssociatedFactories['application/json'] =
+      _CatFactsParseNodeFactory();
+  var client = KiotaClientFactory.createClient();
+  var authProvider = AnonymousAuthenticationProvider();
+
+  // Create the adapter
+  var adapter = HttpClientRequestAdapter(
+    client: client,
+    authProvider: authProvider,
+    pNodeFactory: ParseNodeFactoryRegistry.defaultInstance,
+    sWriterFactory: SerializationWriterFactoryRegistry.defaultInstance,
+  );
+
+  // Send a request
+  final response = await adapter.sendPrimitive<String>(RequestInformation(
+    httpMethod: HttpMethod.get,
+    urlTemplate: 'https://catfact.ninja/fact{?max_length}',
+    pathParameters: {
+      'max_length': 50,
+    },
+  ));
+
+  print(response);
+}
+
+class _CatFactsParseNodeFactory implements ParseNodeFactory {
+  @override
+  ParseNode getRootParseNode(String contentType, Uint8List content) {
+    final text = utf8.decode(content);
+    final json = jsonDecode(text);
+
+    return _CatFactsParseNode(json);
+  }
+
+  @override
+  final validContentType = 'application/json';
+}
+
+class _CatFactsParseNode implements ParseNode {
+  _CatFactsParseNode(this.json);
+
+  final Map<String, dynamic> json;
+
+  String? getStringValue() => json['fact'] as String?;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/packages/kiota_http/example/pubspec.yaml
+++ b/packages/kiota_http/example/pubspec.yaml
@@ -1,0 +1,11 @@
+name: kiota_http_example
+publish_to: 'none'
+
+environment:
+  sdk: '>=3.2.6 <4.0.0'
+
+dependencies:
+  kiota_http:
+    path: ../
+  kiota_abstractions:
+    path: ../../kiota_abstractions

--- a/packages/kiota_http/pubspec.yaml
+++ b/packages/kiota_http/pubspec.yaml
@@ -1,7 +1,8 @@
 name: kiota_http
-description: "Kiota http client for Dart"
+description: "Provides an implementation of a Kiota RequestAdapter that uses `http`."
 version: 0.0.1-pre.1
-homepage: https://github.com/ricardoboss/dart_kiota_abstractions/tree/main/packages/kiota_http
+homepage: https://github.com/ricardoboss/dart_kiota/tree/main/packages/kiota_http
+repository: https://github.com/ricardoboss/dart_kiota
 publish_to: 'none'
 
 environment:
@@ -10,9 +11,9 @@ environment:
 dependencies:
   kiota_abstractions:
     path: ../kiota_abstractions
-  http: ^1.2.1
-  http_parser: ^4.0.2
-  uuid: ^4.3.3
+  http: ^1.2.2
+  http_parser: ^4.1.0
+  uuid: ^4.4.2
 
 dev_dependencies:
   strict: ^2.0.0

--- a/packages/kiota_serialization_form/CHANGELOG.md
+++ b/packages/kiota_serialization_form/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Unreleased
+
+- Initial version.
+- Provides parsing and serialization support for the `application/x-www-form-urlencoded` content type.

--- a/packages/kiota_serialization_form/lib/src/form_parse_node.dart
+++ b/packages/kiota_serialization_form/lib/src/form_parse_node.dart
@@ -87,7 +87,9 @@ class FormParseNode implements ParseNode {
   }
 
   @override
-  Iterable<T> getCollectionOfEnumValues<T extends Enum>(EnumFactory<T> parser) sync* {
+  Iterable<T> getCollectionOfEnumValues<T extends Enum>(
+    EnumFactory<T> parser,
+  ) sync* {
     final collection =
         _decodedValue.split(',').where((entry) => entry.isNotEmpty);
 

--- a/packages/kiota_serialization_form/lib/src/form_serialization_writer.dart
+++ b/packages/kiota_serialization_form/lib/src/form_serialization_writer.dart
@@ -70,7 +70,7 @@ class FormSerializationWriter implements SerializationWriter {
   void writeCollectionOfEnumValues<T extends Enum>(
     String? key,
     Iterable<T>? values,
-      EnumSerializer<T> serializer,
+    EnumSerializer<T> serializer,
   ) {
     if (values == null) {
       return;

--- a/packages/kiota_serialization_form/pubspec.yaml
+++ b/packages/kiota_serialization_form/pubspec.yaml
@@ -1,7 +1,8 @@
 name: kiota_serialization_form
-description: "Kiota serialization for form data"
+description: "Provides parsing and serialization support for the `application/x-www-form-urlencoded` content type."
 version: 0.0.1-pre.1
-homepage: https://github.com/ricardoboss/dart_kiota_abstractions/tree/main/packages/kiota_serialization_form
+homepage: https://github.com/ricardoboss/dart_kiota/tree/main/packages/kiota_serialization_form
+repository: https://github.com/ricardoboss/dart_kiota
 publish_to: 'none'
 
 environment:
@@ -10,7 +11,7 @@ environment:
 dependencies:
   kiota_abstractions:
     path: ../kiota_abstractions
-  uuid: ^4.3.3
+  uuid: ^4.4.2
 
 dev_dependencies:
   build_runner: ^2.4.9

--- a/packages/kiota_serialization_form/test/form_serialization_writer_test.dart
+++ b/packages/kiota_serialization_form/test/form_serialization_writer_test.dart
@@ -23,7 +23,10 @@ void main() {
           _httpMethodEnumSerializer,
         );
 
-      expect(utf8.decode(writer.getSerializedContent()), equals('key=get%2Cpost'));
+      expect(
+        utf8.decode(writer.getSerializedContent()),
+        equals('key=get%2Cpost'),
+      );
     });
   });
 }

--- a/packages/kiota_serialization_text/CHANGELOG.md
+++ b/packages/kiota_serialization_text/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Unreleased
+
+- Initial version.
+- Provides parsing and serialization support for the `text/plain` content type.

--- a/packages/kiota_serialization_text/pubspec.yaml
+++ b/packages/kiota_serialization_text/pubspec.yaml
@@ -1,7 +1,8 @@
 name: kiota_serialization_text
-description: "Kiota text serialization for Dart"
+description: "Provides parsing and serialization support for the `text/plain` content type."
 version: 0.0.1-pre.1
 homepage: https://github.com/ricardoboss/dart_kiota/tree/main/packages/kiota_serialization_text
+repository: https://github.com/ricardoboss/dart_kiota
 publish_to: 'none'
 
 environment:
@@ -10,7 +11,7 @@ environment:
 dependencies:
   kiota_abstractions:
     path: ../kiota_abstractions
-  uuid: ^4.3.3
+  uuid: ^4.4.2
 
 dev_dependencies:
   strict: ^2.0.0

--- a/packages/kiota_serialization_text/test/text_parse_node_test.dart
+++ b/packages/kiota_serialization_text/test/text_parse_node_test.dart
@@ -160,7 +160,8 @@ void main() {
       final node = TextParseNode('value');
 
       expect(
-        () => node.getCollectionOfEnumValues<HttpMethod>(_httpMethodEnumFactory),
+        () =>
+            node.getCollectionOfEnumValues<HttpMethod>(_httpMethodEnumFactory),
         throwsNoStructuredDataError,
       );
     });

--- a/packages/kiota_serialization_text/test/text_test_helper.dart
+++ b/packages/kiota_serialization_text/test/text_test_helper.dart
@@ -2,7 +2,7 @@ import 'package:test/test.dart';
 
 final throwsNoStructuredDataError = throwsA(
   isA<UnsupportedError>().having(
-        (e) => e.message,
+    (e) => e.message,
     'message',
     equals('Text does not support structured data'),
   ),

--- a/tooling/.gitignore
+++ b/tooling/.gitignore
@@ -1,0 +1,3 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/

--- a/tooling/analysis_options.yaml
+++ b/tooling/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/tooling/bin/tooling.dart
+++ b/tooling/bin/tooling.dart
@@ -1,0 +1,9 @@
+import 'package:args/command_runner.dart';
+import 'package:tooling/tooling.dart';
+
+void main(List<String> args) {
+  final runner = CommandRunner("tooling", "Tooling for Dart Kiota")
+    ..addCommand(PrepareCommand());
+
+  runner.run(args);
+}

--- a/tooling/lib/src/prepare_command.dart
+++ b/tooling/lib/src/prepare_command.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:yaml/yaml.dart';
+
+class PrepareCommand extends Command {
+  @override
+  final description = "Prepares a package for publishing";
+
+  @override
+  final name = "prepare";
+
+  @override
+  void run() {
+    final package = argResults!.rest.firstOrNull;
+    if (package == null) {
+      stdout.writeln('No package specified. Running for all packages');
+
+      _runForAllPackages();
+
+      return;
+    }
+
+    _runForPackage(package);
+
+    stdout.writeln('Done');
+  }
+
+  void _runForAllPackages() {
+    for (final package in Directory('packages').listSync()) {
+      if (package is Directory) {
+        _runForPackage(package.path.split(Platform.pathSeparator).last);
+      }
+    }
+  }
+
+  void _runForPackage(String package) {
+    stdout
+      ..writeln()
+      ..writeln('Preparing $package');
+
+    _runBuildRunner(package);
+    _copyLicense(package);
+
+    stdout.writeln('Done');
+  }
+
+  bool _packageRequiresBuildRunner(String package) {
+    final pubspec = File('packages/$package/pubspec.yaml');
+    if (!pubspec.existsSync()) {
+      stderr.writeln('No pubspec.yaml found for $package!');
+
+      return false;
+    }
+
+    final pubspecContent = pubspec.readAsStringSync();
+    final pubspecMap = loadYaml(pubspecContent);
+    final buildRunner = pubspecMap['dev_dependencies']['build_runner'];
+
+    return buildRunner != null;
+  }
+
+  void _runBuildRunner(String package) {
+    if (!_packageRequiresBuildRunner(package)) {
+      return;
+    }
+
+    stdout.writeln('Running build_runner for $package');
+
+    final result = Process.runSync(
+      'dart',
+      ['run', 'build_runner', 'build', '--delete-conflicting-outputs'],
+      workingDirectory: 'packages/$package',
+    );
+
+    if (result.exitCode != 0) {
+      stderr.writeln('Error running build_runner: ${result.stderr}');
+
+      exit(1);
+    }
+  }
+
+  void _copyLicense(String package) {
+    final license = File('LICENSE');
+    if (!license.existsSync()) {
+      stderr.writeln('No LICENSE file found!');
+
+      return;
+    }
+
+    final licenseContent = license.readAsStringSync();
+
+    final licenseFile = File('packages/$package/LICENSE');
+
+    licenseFile.writeAsStringSync(licenseContent);
+  }
+}

--- a/tooling/lib/src/prepare_command.dart
+++ b/tooling/lib/src/prepare_command.dart
@@ -12,6 +12,9 @@ class PrepareCommand extends Command {
 
   @override
   void run() {
+    // change to the root directory
+    Directory.current = Directory.current.parent;
+
     final package = argResults!.rest.firstOrNull;
     if (package == null) {
       stdout.writeln('No package specified. Running for all packages');

--- a/tooling/lib/src/prepare_command.dart
+++ b/tooling/lib/src/prepare_command.dart
@@ -25,8 +25,6 @@ class PrepareCommand extends Command {
     }
 
     _runForPackage(package);
-
-    stdout.writeln('Done');
   }
 
   void _runForAllPackages() {

--- a/tooling/lib/tooling.dart
+++ b/tooling/lib/tooling.dart
@@ -1,0 +1,3 @@
+library tooling;
+
+export 'src/prepare_command.dart';

--- a/tooling/pubspec.yaml
+++ b/tooling/pubspec.yaml
@@ -1,0 +1,14 @@
+name: tooling
+description: A sample command-line application.
+version: 1.0.0
+
+environment:
+  sdk: ^3.4.3
+
+dependencies:
+  args: ^2.5.0
+  yaml: ^3.1.2
+
+dev_dependencies:
+  lints: ^3.0.0
+  test: ^1.24.0


### PR DESCRIPTION
Runs axel-op/dart-package-analyzer@v3 to determine which points would be given to each package on pub.dev.

Also adds package discovery to the workflow so that only packages requiring `build_runner` will need to be added manually.